### PR TITLE
Constrain ModemManager versions to even-stable/odd-unstable versioning scheme

### DIFF
--- a/org.gnome.Calls.yaml
+++ b/org.gnome.Calls.yaml
@@ -47,7 +47,8 @@ modules:
           type: git
           # NOTE tag 0.3 is not semantic versioning
           #version-scheme: semantic
-          tag-pattern: ^([\d.]+)$
+          # NOTE even-stable/odd-unstable versioning scheme
+          tag-pattern: ^(\d+\.\d*[02468]\.\d+)$
   - name: libpeas
     buildsystem: meson
     config-opts:


### PR DESCRIPTION
Fixes https://github.com/flathub/org.gnome.Calls/pull/77#issuecomment-1385890601