### PR TITLE
use proper D-Bus activation

### DIFF
--- a/org.gnome.Calls.json
+++ b/org.gnome.Calls.json
@@ -412,6 +412,9 @@
                 "-Dsystemd_user_unit_dir=/app/lib/systemd/user",
                 "--wrap-mode=nodownload"
             ],
+            "post-install": [
+                "sed -i '/^SystemdService=/d' /app/share/dbus-1/services/org.gnome.Calls.service"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
The D-Bus service description instructed systemd to run a systemd service instead. That service is not installed, because flatpak does not support exporting systemd services.

If systemd-aware D-Bus brokers are used, this would lead to Calls not starting.